### PR TITLE
FLY-2589: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ QA-Test, Stable-Test, master ]
+    branches: [ main, QA-Test, Stable-Test, master ]
   pull_request:
   workflow_dispatch:
 
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -33,9 +36,11 @@ jobs:
       - name: Unit test smart contracts with coverage
         run: npm run test:coverage
 
+      # Skipped when CODECOV_TOKEN is absent: fork PRs get no secrets, and the token does not exist yet (FLY-2600).
       - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,13 @@ jobs:
 
       - name: Unit test smart contracts
         run: npm test
+
+      - name: Unit test smart contracts with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,17 @@ jobs:
       - name: Unit test smart contracts with coverage
         run: npm run test:coverage
 
-      # Gates the upload: fork PRs get no secrets, and this repo has no CODECOV_TOKEN until Codecov onboarding (FLY-2600).
+      # Gates the upload: fork PRs get no secrets, and this repo has no CODECOV_TOKEN until Codecov onboarding lands.
       - name: Check for Codecov token
         id: codecov-token
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           [ -n "$CODECOV_TOKEN" ] && echo "present=true" >> "$GITHUB_OUTPUT" || echo "present=false" >> "$GITHUB_OUTPUT"
+
+      - name: TEMP expression probe - delete before merge
+        if: steps.codecov-token.outputs.present == 'false'
+        run: echo "hyphenated step id resolved via dot notation"
 
       - name: Upload coverage to Codecov
         if: steps.codecov-token.outputs.present == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
@@ -36,11 +33,18 @@ jobs:
       - name: Unit test smart contracts with coverage
         run: npm run test:coverage
 
-      # Skipped when CODECOV_TOKEN is absent: fork PRs get no secrets, and the token does not exist yet (FLY-2600).
+      # Gates the upload: fork PRs get no secrets, and this repo has no CODECOV_TOKEN yet (Codecov onboarding pending).
+      - name: Check for Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          [ -n "$CODECOV_TOKEN" ] && echo "present=true" >> "$GITHUB_OUTPUT" || echo "present=false" >> "$GITHUB_OUTPUT"
+
       - name: Upload coverage to Codecov
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: steps.codecov-token.outputs.present == 'true'
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,6 @@ jobs:
         run: |
           [ -n "$CODECOV_TOKEN" ] && echo "present=true" >> "$GITHUB_OUTPUT" || echo "present=false" >> "$GITHUB_OUTPUT"
 
-      - name: TEMP expression probe - delete before merge
-        if: steps.codecov-token.outputs.present == 'false'
-        run: echo "hyphenated step id resolved via dot notation"
-
       - name: Upload coverage to Codecov
         if: steps.codecov-token.outputs.present == 'true'
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Unit test smart contracts with coverage
         run: npm run test:coverage
 
-      # Gates the upload: fork PRs get no secrets, and this repo has no CODECOV_TOKEN yet (Codecov onboarding pending).
+      # Gates the upload: fork PRs get no secrets, and this repo has no CODECOV_TOKEN until Codecov onboarding (FLY-2600).
       - name: Check for Codecov token
         id: codecov-token
         env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rsksmart/btc-transaction-solidity-helper/badge)](https://scorecard.dev/viewer/?uri=github.com/rsksmart/btc-transaction-solidity-helper)
+[![codecov](https://codecov.io/gh/rsksmart/btc-transaction-solidity-helper/branch/main/graph/badge.svg)](https://codecov.io/gh/rsksmart/btc-transaction-solidity-helper)
 <img src="img/rootstock-docs.png" alt="RSK Logo" style="width:100%; height: auto;" />
 
 # BTC Transaction Solidity Helper

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # baseline is always the current main value
+        threshold: 1%   # allow up to 1% drop before failing the check
+    patch:
+      default:
+        target: 80%     # new/changed lines in a PR must be at least 80% covered
+        threshold: 5%   # allow up to 5% below target before failing
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true  # only post a comment when coverage actually changes
+
+ignore:
+  - "test/**"
+  - "scripts/**"


### PR DESCRIPTION
## What

Adds Codecov coverage reporting: a `codecov.yml` at the repo root, a coverage run and upload step in CI, and a coverage badge in the README.

## Why

This library parses BTC transactions and output scripts for `liquidity-bridge-contract`, so a defect here reaches the bridge on-chain. CI already ran `hardhat coverage` and threw the result away. Now every PR shows its coverage delta, as `liquidity-provider-server` does.

## How to verify

- `npm run test:coverage` writes LCOV to `coverage/lcov.info`. Verified locally: 35 tests pass, contracts at 98.85% statements.
- `.github/workflows/ci.yml` runs that script and uploads the file with `codecov/codecov-action`, SHA-pinned like every other action in the file.
- `codecov.yml` mirrors the LPS thresholds: project target auto, threshold 1%; patch target 80%, threshold 5%. Ignores `test/**` and `scripts/**`.

The Codecov upload will not work until Codecov onboarding and a repo-scoped `CODECOV_TOKEN` Actions secret exist for `rsksmart/btc-transaction-solidity-helper`. Tracked as FLY-2600, currently unassigned.

## Related issues

- Jira: [FLY-2589](https://rsklabs.atlassian.net/browse/FLY-2589)
